### PR TITLE
为每个核心要点生成独立卡片并应用美学风格

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -328,7 +328,31 @@ main {
     border-radius: var(--border-radius);
     box-shadow: var(--shadow);
     position: relative;
+    overflow: auto;
+}
+
+/* 多卡片容器 */
+.cards-container {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    padding: 20px;
+}
+
+.card-wrapper {
+    width: 100%;
+    margin-bottom: 20px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    border-radius: var(--border-radius);
     overflow: hidden;
+}
+
+/* 导出模式选项 */
+.export-mode-option {
+    margin: 15px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
 }
 
 .loading-indicator {
@@ -453,33 +477,33 @@ footer {
     .container {
         padding: 15px;
     }
-    
+
     header h1 {
         font-size: 2rem;
     }
-    
+
     .section {
         padding: 20px;
     }
-    
+
     .card-preview {
         width: 100%;
         height: 0;
         padding-bottom: 66.67%; /* 保持3:2比例 */
     }
-    
+
     .customization-options {
         grid-template-columns: 1fr;
     }
-    
+
     .templates {
         gap: 10px;
     }
-    
+
     .template {
         width: 100px;
     }
-    
+
     .template-preview {
         height: 67px;
     }
@@ -489,34 +513,34 @@ footer {
     header h1 {
         font-size: 1.8rem;
     }
-    
+
     .step-number {
         width: 40px;
         height: 40px;
         font-size: 1rem;
     }
-    
+
     .step-title {
         font-size: 0.8rem;
     }
-    
+
     .button-container {
         flex-direction: column;
         gap: 10px;
     }
-    
+
     .primary-btn, .secondary-btn {
         width: 100%;
     }
-    
+
     .templates {
         justify-content: space-between;
     }
-    
+
     .template {
         width: 80px;
     }
-    
+
     .template-preview {
         height: 53px;
     }

--- a/index.html
+++ b/index.html
@@ -81,6 +81,13 @@
                         <h3>自定义选项</h3>
                         <div class="customization-options">
                             <div class="option">
+                                <label for="render-mode">渲染模式</label>
+                                <select id="render-mode">
+                                    <option value="multiple">多卡片模式（每个要点一张）</option>
+                                    <option value="single">单卡片模式（全部内容一张）</option>
+                                </select>
+                            </div>
+                            <div class="option">
                                 <label for="bg-color">背景颜色</label>
                                 <input type="color" id="bg-color" value="#ffffff">
                             </div>
@@ -132,6 +139,13 @@
                         <div class="format-options">
                             <button id="export-png" class="format-btn">PNG格式</button>
                             <button id="export-jpg" class="format-btn">JPG格式</button>
+                        </div>
+                        <div class="export-mode-option">
+                            <label for="export-mode">导出模式</label>
+                            <select id="export-mode">
+                                <option value="all">导出所有卡片</option>
+                                <option value="current">仅导出当前卡片</option>
+                            </select>
                         </div>
                         <div class="resolution-option">
                             <label for="resolution">分辨率</label>

--- a/js/cardRenderer.js
+++ b/js/cardRenderer.js
@@ -10,6 +10,12 @@ class CardRenderer {
             fontSize: 16,
             signature: ''
         };
+
+        // 渲染模式：'single'(单卡片) 或 'multiple'(多卡片)
+        this.renderMode = 'multiple';
+
+        // 存储多张卡片的引用
+        this.cardElements = [];
     }
 
     /**
@@ -29,33 +35,109 @@ class CardRenderer {
     }
 
     /**
+     * 设置渲染模式
+     * @param {string} mode 渲染模式 ('single' 或 'multiple')
+     */
+    setRenderMode(mode) {
+        if (mode === 'single' || mode === 'multiple') {
+            this.renderMode = mode;
+        }
+    }
+
+    /**
      * 渲染卡片
      * @param {object} content 结构化内容
      * @param {HTMLElement} container 容器元素
      */
     renderCard(content, container) {
         return new Promise((resolve) => {
-            // 清空容器
+            // 清空容器和卡片引用数组
             container.innerHTML = '';
-            
-            // 创建卡片元素
-            const card = document.createElement('div');
-            card.className = `card ${this.currentTemplate}`;
-            
-            // 应用自定义样式
-            this.applyCustomStyles(card);
-            
-            // 创建卡片内容
-            this.createCardContent(card, content);
-            
-            // 添加到容器
-            container.appendChild(card);
-            
+            this.cardElements = [];
+
+            if (this.renderMode === 'multiple' && content.points && content.points.length > 0) {
+                // 多卡片模式 - 为每个要点创建单独的卡片
+                this.renderMultipleCards(content, container);
+            } else {
+                // 单卡片模式 - 创建一个包含所有内容的卡片
+                const card = this.createSingleCard(content);
+                container.appendChild(card);
+                this.cardElements.push(card);
+            }
+
             // 模拟渲染延迟
             setTimeout(() => {
                 resolve(true);
             }, 500);
         });
+    }
+
+    /**
+     * 创建单个完整卡片
+     * @param {object} content 结构化内容
+     * @returns {HTMLElement} 卡片元素
+     */
+    createSingleCard(content) {
+        // 创建卡片元素
+        const card = document.createElement('div');
+        card.className = `card ${this.currentTemplate}`;
+
+        // 应用自定义样式
+        this.applyCustomStyles(card);
+
+        // 创建卡片内容
+        this.createCardContent(card, content);
+
+        return card;
+    }
+
+    /**
+     * 渲染多张卡片 - 每个要点一张
+     * @param {object} content 结构化内容
+     * @param {HTMLElement} container 容器元素
+     */
+    renderMultipleCards(content, container) {
+        if (!content.points || content.points.length === 0) return;
+
+        // 创建卡片容器
+        const cardsContainer = document.createElement('div');
+        cardsContainer.className = 'cards-container';
+
+        // 为每个要点创建卡片
+        content.points.forEach((point, index) => {
+            // 创建单点卡片内容
+            const pointContent = {
+                title: content.title || '读书笔记',
+                intro: index === 0 ? content.intro : '',
+                points: [point],
+                conclusion: index === content.points.length - 1 ? content.conclusion : ''
+            };
+
+            // 创建卡片元素
+            const card = document.createElement('div');
+            card.className = `card ${this.currentTemplate}`;
+            card.dataset.pointIndex = index;
+
+            // 应用自定义样式
+            this.applyCustomStyles(card);
+
+            // 创建卡片内容
+            this.createCardContent(card, pointContent);
+
+            // 创建卡片容器
+            const cardWrapper = document.createElement('div');
+            cardWrapper.className = 'card-wrapper';
+            cardWrapper.appendChild(card);
+
+            // 添加到容器
+            cardsContainer.appendChild(cardWrapper);
+
+            // 存储卡片引用
+            this.cardElements.push(card);
+        });
+
+        // 添加到主容器
+        container.appendChild(cardsContainer);
     }
 
     /**
@@ -65,12 +147,12 @@ class CardRenderer {
     applyCustomStyles(card) {
         // 背景颜色
         card.style.backgroundColor = this.customOptions.bgColor;
-        
+
         // 字体样式
         if (this.customOptions.fontFamily !== 'default') {
             card.style.fontFamily = this.getFontFamily(this.customOptions.fontFamily);
         }
-        
+
         // 字体大小
         card.style.fontSize = `${this.customOptions.fontSize}px`;
     }
@@ -102,16 +184,16 @@ class CardRenderer {
         // 创建卡片头部
         const header = document.createElement('div');
         header.className = 'card-header';
-        
+
         // 创建标题
         const title = document.createElement('div');
         title.className = 'card-title';
         title.textContent = content.title || '读书笔记';
         header.appendChild(title);
-        
+
         // 添加头部到卡片
         card.appendChild(header);
-        
+
         // 创建引言
         if (content.intro) {
             const intro = document.createElement('div');
@@ -119,22 +201,22 @@ class CardRenderer {
             intro.textContent = content.intro;
             card.appendChild(intro);
         }
-        
+
         // 创建核心要点
         if (content.points && content.points.length > 0) {
             const pointsContainer = document.createElement('div');
             pointsContainer.className = 'card-points';
-            
+
             content.points.forEach(point => {
                 const pointElement = document.createElement('div');
                 pointElement.className = 'card-point';
                 pointElement.textContent = point;
                 pointsContainer.appendChild(pointElement);
             });
-            
+
             card.appendChild(pointsContainer);
         }
-        
+
         // 创建结论
         if (content.conclusion) {
             const conclusion = document.createElement('div');
@@ -142,7 +224,7 @@ class CardRenderer {
             conclusion.textContent = content.conclusion;
             card.appendChild(conclusion);
         }
-        
+
         // 添加签名
         if (this.customOptions.signature) {
             const signature = document.createElement('div');
@@ -154,47 +236,62 @@ class CardRenderer {
 
     /**
      * 将卡片渲染为图像
-     * @param {HTMLElement} cardElement 卡片元素
+     * @param {HTMLElement|number} cardElementOrIndex 卡片元素或卡片索引
      * @param {string} format 图像格式 ('png' 或 'jpg')
      * @param {number} resolution 分辨率
      * @returns {Promise<string>} 图像数据URL
      */
-    renderToImage(cardElement, format = 'png', resolution = 1080) {
+    renderToImage(cardElementOrIndex, format = 'png', resolution = 1080) {
         return new Promise((resolve, reject) => {
             try {
+                // 确定要渲染的卡片元素
+                let cardElement;
+
+                if (typeof cardElementOrIndex === 'number') {
+                    // 如果传入的是索引，从卡片数组中获取
+                    if (cardElementOrIndex >= 0 && cardElementOrIndex < this.cardElements.length) {
+                        cardElement = this.cardElements[cardElementOrIndex];
+                    } else {
+                        reject(new Error('无效的卡片索引'));
+                        return;
+                    }
+                } else {
+                    // 直接使用传入的元素
+                    cardElement = cardElementOrIndex;
+                }
+
                 // 使用html2canvas库渲染DOM为图像
-                // 注意：实际应用中需要引入html2canvas库
                 if (typeof html2canvas === 'undefined') {
                     // 模拟html2canvas功能
                     console.log('使用模拟的html2canvas功能');
-                    
+
                     // 创建一个canvas元素
                     const canvas = document.createElement('canvas');
                     const width = cardElement.offsetWidth;
                     const height = cardElement.offsetHeight;
-                    
+
                     // 设置分辨率
                     const scale = resolution / Math.max(width, height * 1.5);
                     canvas.width = width * scale;
                     canvas.height = height * scale;
-                    
+
                     // 获取上下文
                     const ctx = canvas.getContext('2d');
-                    
+
                     // 设置背景色
                     ctx.fillStyle = this.customOptions.bgColor;
                     ctx.fillRect(0, 0, canvas.width, canvas.height);
-                    
+
                     // 绘制一些模拟内容
                     ctx.fillStyle = '#333';
                     ctx.font = `${20 * scale}px Arial`;
                     ctx.fillText('卡片图像渲染示例', 50 * scale, 50 * scale);
-                    
+
                     // 返回数据URL
                     const imageType = format === 'jpg' ? 'image/jpeg' : 'image/png';
                     const quality = format === 'jpg' ? 0.9 : undefined;
                     const dataUrl = canvas.toDataURL(imageType, quality);
-                    
+
                     setTimeout(() => {
                         resolve(dataUrl);
                     }, 1000);
@@ -206,7 +303,7 @@ class CardRenderer {
                         allowTaint: true,
                         backgroundColor: this.customOptions.bgColor
                     };
-                    
+
                     html2canvas(cardElement, options).then(canvas => {
                         const imageType = format === 'jpg' ? 'image/jpeg' : 'image/png';
                         const quality = format === 'jpg' ? 0.9 : undefined;
@@ -216,6 +313,32 @@ class CardRenderer {
                         reject(error);
                     });
                 }
+            } catch (error) {
+                reject(error);
+            }
+        });
+    }
+
+    /**
+     * 将所有卡片渲染为图像
+     * @param {string} format 图像格式 ('png' 或 'jpg')
+     * @param {number} resolution 分辨率
+     * @returns {Promise<string[]>} 图像数据URL数组
+     */
+    renderAllToImages(format = 'png', resolution = 1080) {
+        return new Promise(async (resolve, reject) => {
+            try {
+                if (this.cardElements.length === 0) {
+                    resolve([]);
+                    return;
+                }
+
+                const imagePromises = this.cardElements.map((card, index) =>
+                    this.renderToImage(index, format, resolution)
+                );
+
+                const images = await Promise.all(imagePromises);
+                resolve(images);
             } catch (error) {
                 reject(error);
             }

--- a/js/exportUtils.js
+++ b/js/exportUtils.js
@@ -3,7 +3,7 @@
  */
 class ExportUtils {
     /**
-     * 导出图像
+     * 导出单张图像
      * @param {string} dataUrl 图像数据URL
      * @param {string} format 图像格式 ('png' 或 'jpg')
      * @param {string} filename 文件名（不含扩展名）
@@ -15,15 +15,47 @@ class ExportUtils {
                 const link = document.createElement('a');
                 link.href = dataUrl;
                 link.download = `${filename}.${format}`;
-                
+
                 // 模拟点击下载
                 document.body.appendChild(link);
                 link.click();
                 document.body.removeChild(link);
-                
+
                 resolve(true);
             } catch (error) {
                 console.error('导出图像失败:', error);
+                resolve(false);
+            }
+        });
+    }
+
+    /**
+     * 导出多张图像
+     * @param {string[]} dataUrls 图像数据URL数组
+     * @param {string} format 图像格式 ('png' 或 'jpg')
+     * @param {string} baseFilename 基础文件名（不含扩展名）
+     */
+    static exportMultipleImages(dataUrls, format = 'png', baseFilename = '小红书读书卡片') {
+        return new Promise(async (resolve) => {
+            try {
+                // 记录成功导出的数量
+                let successCount = 0;
+
+                // 依次导出每张图像
+                for (let i = 0; i < dataUrls.length; i++) {
+                    const filename = `${baseFilename}_${i + 1}`;
+                    const success = await this.exportImage(dataUrls[i], format, filename);
+                    if (success) successCount++;
+
+                    // 添加小延迟，避免浏览器阻止多个下载
+                    if (i < dataUrls.length - 1) {
+                        await new Promise(r => setTimeout(r, 300));
+                    }
+                }
+
+                resolve(successCount === dataUrls.length);
+            } catch (error) {
+                console.error('导出多张图像失败:', error);
                 resolve(false);
             }
         });
@@ -40,22 +72,22 @@ class ExportUtils {
                 resolve(true);
                 return;
             }
-            
+
             // 创建script元素
             const script = document.createElement('script');
             script.src = 'https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js';
             script.async = true;
-            
+
             // 设置加载事件
             script.onload = () => {
                 resolve(true);
             };
-            
+
             script.onerror = () => {
                 console.error('加载html2canvas库失败');
                 resolve(false);
             };
-            
+
             // 添加到文档
             document.head.appendChild(script);
         });


### PR DESCRIPTION
## 功能实现

本PR实现了两个主要需求：

1. **为每个核心要点生成独立的小红书风格卡片**
   - 添加了多卡片渲染模式，每个要点生成一张独立卡片
   - 用户可以在UI中选择单卡片或多卡片模式

2. **确保导出的图片应用了选中的美学风格**
   - 确保每个卡片都应用了选定的模板和样式
   - 支持批量导出多张卡片
   - 添加了导出模式选项（所有卡片或仅当前卡片）

## 修改内容

1. **js/cardRenderer.js**
   - 添加了渲染模式和卡片元素数组
   - 实现了多卡片渲染和批量导出功能

2. **js/exportUtils.js**
   - 添加了批量导出多张图片的功能

3. **js/app.js**
   - 添加了渲染模式切换和多卡片导出功能
   - 更新了事件绑定

4. **index.html**
   - 添加了渲染模式和导出模式选择UI

5. **css/styles.css**
   - 添加了多卡片显示的样式

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author